### PR TITLE
fix: to delete unnecessary encryptHeaders in editUser

### DIFF
--- a/src/components/pages/User.vue
+++ b/src/components/pages/User.vue
@@ -213,9 +213,9 @@ export default {
         .put("/api/v1/auth", inputData, {
           headers: this.authHeader,
         })
-        .then((res) => {
-          this.encryptHeaders(res);
+        .then(() => {
           this.userEditErrors = [];
+          this.authHeader = { "access-token": "", client: "", uid: "" };
           this.noticeMessage = "変更を受け付けました。";
           setTimeout(() => {
             this.noticeMessage = "";


### PR DESCRIPTION
・ユーザーアカウント編集の処理の中で、不必要にヘッダーを暗号化・登録していたため、その処理を削除した（ユーザー編集時に送るアクセストークンと却ってくるアクセストークンは同じ物）。